### PR TITLE
Update esphome-docs references to esphome.io

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/documentation.yml
+++ b/.github/DISCUSSION_TEMPLATE/documentation.yml
@@ -12,7 +12,7 @@ body:
         - 🆘 In need for support? → [Community Forum](https://community.home-assistant.io/c/esphome/36) or join our [Discord chat server](https://esphome.io/chat). You are more likely to get the answer you are looking for in those places.
         - 📄 Improvements to specific component documentation → Use the "Edit this page on GitHub" link at the bottom of that component's documentation page
         - ✏️ Fixing typos or small updates → [Edit directly on the docs site](https://esphome.io/) using the "Edit this page on GitHub" link
-        - 🐛 Reporting documentation errors → [Open an issue in the docs repo](https://github.com/esphome/esphome-docs/issues)
+        - 🐛 Reporting documentation errors → [Open an issue in the docs repo](https://github.com/esphome/esphome.io/issues)
 
   - type: textarea
     id: improvement_description

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -25,7 +25,7 @@ jobs:
               '',
               '- [ESPHome core](https://github.com/esphome/esphome/issues) - compilation issues, runtime crashes and other core issues',
               '- [Dashboard / Builder](https://github.com/esphome/dashboard/issues) - ESPHome Builder / Dashboard bugs',
-              '- [Documentation](https://github.com/esphome/esphome-docs/issues) - issues with the website and documentation',
+              '- [Documentation](https://github.com/esphome/esphome.io/issues) - issues with the website and documentation',
               '- [aioesphomeapi](https://github.com/esphome/aioesphomeapi/issues) - Python API client issues',
               '- [Home Assistant](https://github.com/home-assistant/core/issues) - issues inside Home Assistant while using ESPHome devices',
               '',

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you're experiencing issues or bugs, please use the correct issue tracker depe
 
 - [ESPHome](https://github.com/esphome/esphome/issues) – for compilation issues, runtime crashes and other core issues
 - [Dashboard](https://github.com/esphome/dashboard/issues) – for ESPHome Builder / Dashboard bugs
-- [Documentation](https://github.com/esphome/esphome-docs/issues) - for issues with the ESPHome website and documentation
+- [Documentation](https://github.com/esphome/esphome.io/issues) - for issues with the ESPHome website and documentation
 - [aioesphomeapi](https://github.com/esphome/aioesphomeapi/issues) - Python API client issues
 - [Home Assistant](https://github.com/home-assistant/core/issues) - For issues that come up inside Home Assistant while using ESPHome devices
 


### PR DESCRIPTION
## Summary

The documentation repository has been renamed from `esphome-docs` to `esphome.io`. This updates the issue tracker links in the README, the documentation discussion template, and the auto-close workflow comment so users are pointed at the correct repository.